### PR TITLE
Revise auth, welcome, contact, about content

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,13 +12,8 @@
 
       <header class="row header-bar" ng-include="'templates/header.html'"> </header>
 
-      <nav class="row" ng-if="!auth.isAuthed()" ng-include="'templates/auth.html'">
-        <!-- show Login / Register links and forms if user not logged in -->
-      </nav>
-
-
       <div class="row" >
-        <div ng-if="auth.isAuthed()" ng-view>
+        <div ng-view>
         <!-- show main page content if user is logged in -->
         <!-- Templates accessed by router render here -->
         </div>

--- a/templates/about.html
+++ b/templates/about.html
@@ -2,4 +2,14 @@
   <h1>{{ title }}</h1>
   <p>JHO is an app for taking the agony out of the job hunt.</p>
 
+  <h2 class="about-title">Why JHO?</h2>
+  <p class="about-text">
+    JHO helps you build, retain, and utilize momentum during your job search.
+  </p>
+  <p class="about-description">
+    Forget losing email threads, endless research to craft cover letters that are never read, and getting filtered out by applicant tracking systems. JHO helps you skip the HR quagmire by building real connections.
+  </p>
+  <p class="about-description">
+    JHO provides curated actionable next steps for your job hunt based on priority and urgency, as well as keeping momentum via reminders about organizations with which you are currently engaged.
+  </p>
 </div>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,5 +1,4 @@
 <div class="stats">
   <h1>{{ title }}</h1>
-  <p>Please contact us, we'd love to hear your feedback.</p>
-
+  <p>Have a feature you love or want? We'd love to hear your feedback. Leave us an <a href="https://github.com/mtvillwock/JHO_Angular_Experimentation/issues">issue</a> on Github or  <a href="mailto:mtvillwock@gmail.com">drop us a line</a> and let us know what we can improve!</p>
 </div>

--- a/templates/header.html
+++ b/templates/header.html
@@ -2,7 +2,7 @@
   <div class="col-6 header-nav">
 
       <div ng-if="!auth.isAuthed()"><a id="title" href="#/auth">JHO</a></div>
-      <div ng-if="auth.isAuthed()"><a id="title" href="#/board">JHO</a></div>
+      <div ng-if="auth.isAuthed()"><a id="title" href="#/welcome">JHO</a></div>
       <!-- <p>Your job hunt, organized</p> -->
 
       <ul>

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,7 +1,8 @@
 <div class="row">
   <div class="col-6 header-nav">
 
-      <div><a id="title" href="#/">JHO</a></div>
+      <div ng-if="!auth.isAuthed()"><a id="title" href="#/auth">JHO</a></div>
+      <div ng-if="auth.isAuthed()"><a id="title" href="#/board">JHO</a></div>
       <!-- <p>Your job hunt, organized</p> -->
 
       <ul>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -1,12 +1,9 @@
 <div class="welcome">
-  <h2 class="splash-title">JHO</h2>
-  <p class="splash-text">
-    JHO helps you build, retain, and utilize momentum during your job search.
-  </p>
-  <p class="splash-description">
-    Forget losing email threads, endless research to craft cover letters that are never read, and getting filtered out by applicant tracking systems. JHO helps you skip the HR quagmire by building real connections.
-  </p>
-  <p class="splash-description">
-    JHO provides curated actionable next steps for your job hunt based on priority and urgency, as well as keeping momentum via reminders about organizations with which you are currently engaged.
-  </p>
+  <h2>Using JHO</h2>
+  <ul>
+    <li>Add organizations to your <a href="#/board">board</a> to start tracking your progress.</li>
+    <li>Review your <a href="#/today">today</a> panel to see the actionable next steps for your day.</li>
+    <li>Check out your <a href="#/stats">stats</a> dashboard to view trends and scores for your search.</li>
+    <li>Read up on the <a href="#/tips">tips</a> tab for inspiring bite-sized advice and encouragement.</li>
+  </ul>
 </div>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -1,9 +1,12 @@
-<div>
-  <h1>{{ title }}</h1>
-  <h3>{{ quote }}</h3>
-  <ul>
-    <li ng-repeat="item in items">{{ item }}</li>
-  </ul>
-
-  <p>Beta: see <a href="#/board">your board</a>!</p>
+<div class="welcome">
+  <h2 class="splash-title">JHO</h2>
+  <p class="splash-text">
+    JHO helps you build, retain, and utilize momentum during your job search.
+  </p>
+  <p class="splash-description">
+    Forget losing email threads, endless research to craft cover letters that are never read, and getting filtered out by applicant tracking systems. JHO helps you skip the HR quagmire by building real connections.
+  </p>
+  <p class="splash-description">
+    JHO provides curated actionable next steps for your job hunt based on priority and urgency, as well as keeping momentum via reminders about organizations with which you are currently engaged.
+  </p>
 </div>


### PR DESCRIPTION
When an user is logged out they can see the About and Contact page.
About page explains the benefits of the app.
Contact page links to Github issues for the client and my email.
Welcome page tells what each panel/tab of the app does.
When a user is logged in, clicking the logo takes them to the Welcome page.
When a user is logged out, clicking the logo takes them to the auth page.

We should change the login and register routes to redirect to the welcome page instead of the board. Or just move the welcome content to the about page. Ideally the about page would have images and descriptions of using the app, ala [Asana](https://asana.com/), [Handle](http://www.handle.com/), or [Trello](https://trello.com/).

It's also odd that the logo sends you to the welcome page but the home nav link goes to the board.
